### PR TITLE
Fix dependency to "React-Core" in podspec

### DIFF
--- a/seatsio-react-native.podspec
+++ b/seatsio-react-native.podspec
@@ -23,7 +23,7 @@ Pod::Spec.new do |s|
   s.source_files = "ios/**/*.{h,c,cc,cpp,m,mm,swift}"
   s.requires_arc = true
 
-  s.dependency "React"
+  s.dependency "React-Core"
   # ...
   # s.dependency "..."
 end


### PR DESCRIPTION
Currently, the projects depending on seatsio-react-native fail to
compile.
This fix was proposed by
https://github.com/facebook/react-native/issues/29633