### PR TITLE
Chart adapts to styling of its parent component

### DIFF
--- a/components/SeatsioSeatingChart.js
+++ b/components/SeatsioSeatingChart.js
@@ -87,6 +87,7 @@ class SeatsioSeatingChart extends React.Component {
                 source={{html: this.html()}}
                 injectedJavaScriptBeforeContentLoaded={this.pipeConsoleLog()}
                 onMessage={this.handleMessage.bind(this)}
+                style={{ backgroundColor: 'transparent' }}
             />
         );
     }
@@ -157,8 +158,8 @@ class SeatsioSeatingChart extends React.Component {
                 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
                 <script src="${this.props.chartJsUrl.replace('{region}', this.props.region)}"></script>
             </head>
-            <body>
-                <div id="${this.divId}"></div>
+            <body style="margin: 0; padding: 0;">
+                <div id="${this.divId}" style="width: 100%; height: 100%;"></div>
                 <script>
                     let promises = [];
                     let promiseCounter = 0;


### PR DESCRIPTION
There were a couple of issues with our React Native component:

- setting a width or height on the parent component didn't have an effect
- setting a background on the parent component didn't have an effect (the chart always had a white background)
- there was some padding around the chart that couldn't be turned off

That's now fixed:

![Screenshot_1696851262](https://github.com/seatsio/seatsio-react-native/assets/1332102/ffdc8b29-4ccc-4e5b-b085-a1493742323f)
