### PR TITLE
RN: seatsio-types -> 6.5.0

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -18,7 +18,7 @@
   "devDependencies": {
     "@babel/core": "7.28.5",
     "@react-native/metro-config": "0.82.1",
-    "@seatsio/seatsio-types": "6.4.0",
+    "@seatsio/seatsio-types": "6.5.0",
     "@types/react": "19.2.7",
     "typescript": "5.9.3"
   },

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -1640,10 +1640,10 @@
 "@seatsio/seatsio-react-native@file:../dist":
   version "0.0.0"
 
-"@seatsio/seatsio-types@6.4.0":
-  version "6.4.0"
-  resolved "https://registry.yarnpkg.com/@seatsio/seatsio-types/-/seatsio-types-6.4.0.tgz#e6e60521ad3f75f1ccec733aee605e6a7a4ab3da"
-  integrity sha512-+2lg2M9qG7D1AjQ67jAJVPyKsgNdc0nEXf8aRsYYBE4ibhgwb9r6VACq8pslvmK7J8sQoP8Exv/QBb3s1BS5Ng==
+"@seatsio/seatsio-types@6.5.0":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@seatsio/seatsio-types/-/seatsio-types-6.5.0.tgz#4d55b288a7dd015fcb849e232c1a88f2dee34ed9"
+  integrity sha512-d7Y8n8MZQL0y9OAUnUReAZmsUt96BLGjZxorFYlITENooMmbpfFhCLR/7v8CzwBe05otT+l4pNCK+o8sygzy3A==
 
 "@sinclair/typebox@^0.27.8":
   version "0.27.8"

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "devDependencies": {
     "@eslint/js": "9.39.1",
-    "@seatsio/seatsio-types": "6.4.0",
+    "@seatsio/seatsio-types": "6.5.0",
     "@stylistic/eslint-plugin": "5.6.1",
     "@swc/core": "1.15.3",
     "@tsconfig/react-native": "3.0.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1356,10 +1356,10 @@
   resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.34.9.tgz#1973871850856ae72bc678aeb066ab952330e923"
   integrity sha512-AyleYRPU7+rgkMWbEh71fQlrzRfeP6SyMnRf9XX4fCdDPAJumdSBqYEcWPMzVQ4ScAl7E4oFfK0GUVn77xSwbw==
 
-"@seatsio/seatsio-types@6.4.0":
-  version "6.4.0"
-  resolved "https://registry.yarnpkg.com/@seatsio/seatsio-types/-/seatsio-types-6.4.0.tgz#e6e60521ad3f75f1ccec733aee605e6a7a4ab3da"
-  integrity sha512-+2lg2M9qG7D1AjQ67jAJVPyKsgNdc0nEXf8aRsYYBE4ibhgwb9r6VACq8pslvmK7J8sQoP8Exv/QBb3s1BS5Ng==
+"@seatsio/seatsio-types@6.5.0":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@seatsio/seatsio-types/-/seatsio-types-6.5.0.tgz#4d55b288a7dd015fcb849e232c1a88f2dee34ed9"
+  integrity sha512-d7Y8n8MZQL0y9OAUnUReAZmsUt96BLGjZxorFYlITENooMmbpfFhCLR/7v8CzwBe05otT+l4pNCK+o8sygzy3A==
 
 "@sinclair/typebox@^0.27.8":
   version "0.27.8"


### PR DESCRIPTION
Update to latest seatsio-types - [6.5.0](https://github.com/seatsio/seatsio-types/releases/tag/v6.5.0) to include `onSelectedObjectUnavailable`

[Trello](https://trello.com/c/LExIT3kR/8797-update-client-libs-with-onselectedobjectunavailable)